### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/171/017/421171017.geojson
+++ b/data/421/171/017/421171017.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"CF",
     "wof:created":1459008879,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9f425ac5fb44acdd1a8c5e71db417f6f",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421171017,
-    "wof:lastmodified":1566638245,
+    "wof:lastmodified":1582347807,
     "wof:name":"Bamingui",
     "wof:parent_id":85669689,
     "wof:placetype":"county",

--- a/data/421/181/445/421181445.geojson
+++ b/data/421/181/445/421181445.geojson
@@ -567,6 +567,9 @@
     ],
     "wof:country":"CF",
     "wof:created":1459009296,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0eab040d1196ff44b3f09d5c1a260f8d",
     "wof:hierarchy":[
         {
@@ -578,7 +581,7 @@
         }
     ],
     "wof:id":421181445,
-    "wof:lastmodified":1566638243,
+    "wof:lastmodified":1582347807,
     "wof:name":"Bangui",
     "wof:parent_id":1108759735,
     "wof:placetype":"locality",

--- a/data/856/323/91/85632391.geojson
+++ b/data/856/323/91/85632391.geojson
@@ -1080,6 +1080,11 @@
     },
     "wof:country":"CF",
     "wof:country_alpha3":"CAF",
+    "wof:geom_alt":[
+        "meso",
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"511aba95ab63ff4737d9efe239ecc99a",
     "wof:hierarchy":[
         {
@@ -1096,7 +1101,7 @@
         "fra",
         "sag"
     ],
-    "wof:lastmodified":1566637829,
+    "wof:lastmodified":1582347796,
     "wof:name":"Central African Republic",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/696/55/85669655.geojson
+++ b/data/856/696/55/85669655.geojson
@@ -539,6 +539,9 @@
         421181445
     ],
     "wof:country":"CF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0eab040d1196ff44b3f09d5c1a260f8d",
     "wof:hierarchy":[
         {
@@ -556,7 +559,7 @@
         "fra",
         "sag"
     ],
-    "wof:lastmodified":1566637839,
+    "wof:lastmodified":1582347800,
     "wof:name":"Bangui",
     "wof:parent_id":85632391,
     "wof:placetype":"region",

--- a/data/856/696/61/85669661.geojson
+++ b/data/856/696/61/85669661.geojson
@@ -298,6 +298,9 @@
         "wk:page":"Ombella-M'Poko"
     },
     "wof:country":"CF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0e29683cacf9582e41a5922e46617681",
     "wof:hierarchy":[
         {
@@ -315,7 +318,7 @@
         "fra",
         "sag"
     ],
-    "wof:lastmodified":1566637835,
+    "wof:lastmodified":1582347799,
     "wof:name":"Ombella M'Poko",
     "wof:parent_id":85632391,
     "wof:placetype":"region",

--- a/data/856/696/65/85669665.geojson
+++ b/data/856/696/65/85669665.geojson
@@ -286,6 +286,9 @@
         "wk:page":"Basse-Kotto"
     },
     "wof:country":"CF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e62f5afe3c8be3dca3760d02d6748ebe",
     "wof:hierarchy":[
         {
@@ -303,7 +306,7 @@
         "fra",
         "sag"
     ],
-    "wof:lastmodified":1566637838,
+    "wof:lastmodified":1582347800,
     "wof:name":"Basse-Kotto",
     "wof:parent_id":85632391,
     "wof:placetype":"region",

--- a/data/856/696/67/85669667.geojson
+++ b/data/856/696/67/85669667.geojson
@@ -292,6 +292,9 @@
         "wk:page":"Lobaye"
     },
     "wof:country":"CF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5e2c9ab75d8a4a35b6b210340530b36c",
     "wof:hierarchy":[
         {
@@ -309,7 +312,7 @@
         "fra",
         "sag"
     ],
-    "wof:lastmodified":1566637836,
+    "wof:lastmodified":1582347799,
     "wof:name":"Lobaye",
     "wof:parent_id":85632391,
     "wof:placetype":"region",

--- a/data/856/696/71/85669671.geojson
+++ b/data/856/696/71/85669671.geojson
@@ -293,6 +293,9 @@
         "wk:page":"Mamb\u00e9r\u00e9-Kad\u00e9\u00ef"
     },
     "wof:country":"CF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0adb57b690db57ecf1880e8bf4eb515e",
     "wof:hierarchy":[
         {
@@ -310,7 +313,7 @@
         "fra",
         "sag"
     ],
-    "wof:lastmodified":1566637840,
+    "wof:lastmodified":1582347801,
     "wof:name":"Mamb\u00e9r\u00e9-Kad\u00e9\u00ef",
     "wof:parent_id":85632391,
     "wof:placetype":"region",

--- a/data/856/696/75/85669675.geojson
+++ b/data/856/696/75/85669675.geojson
@@ -283,6 +283,9 @@
         "wk:page":"Sangha-Mba\u00e9r\u00e9"
     },
     "wof:country":"CF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4a927c21bf013796f3c8a019f616a05d",
     "wof:hierarchy":[
         {
@@ -300,7 +303,7 @@
         "fra",
         "sag"
     ],
-    "wof:lastmodified":1566637837,
+    "wof:lastmodified":1582347800,
     "wof:name":"Sangha-Mba\u00e9r\u00e9",
     "wof:parent_id":85632391,
     "wof:placetype":"region",

--- a/data/856/696/81/85669681.geojson
+++ b/data/856/696/81/85669681.geojson
@@ -290,6 +290,9 @@
         "wk:page":"Nana-Mamb\u00e9r\u00e9"
     },
     "wof:country":"CF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dbb6cba3b199db4cac08d6348a921aeb",
     "wof:hierarchy":[
         {
@@ -307,7 +310,7 @@
         "fra",
         "sag"
     ],
-    "wof:lastmodified":1566637837,
+    "wof:lastmodified":1582347800,
     "wof:name":"Nana-Mamb\u00e9r\u00e9",
     "wof:parent_id":85632391,
     "wof:placetype":"region",

--- a/data/856/696/85/85669685.geojson
+++ b/data/856/696/85/85669685.geojson
@@ -287,6 +287,9 @@
         "wk:page":"Ouham-Pend\u00e9"
     },
     "wof:country":"CF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"41add99f493d45bbe813a36757a07be5",
     "wof:hierarchy":[
         {
@@ -304,7 +307,7 @@
         "fra",
         "sag"
     ],
-    "wof:lastmodified":1566637839,
+    "wof:lastmodified":1582347801,
     "wof:name":"Ouham-Pend\u00e9",
     "wof:parent_id":85632391,
     "wof:placetype":"region",

--- a/data/856/696/89/85669689.geojson
+++ b/data/856/696/89/85669689.geojson
@@ -289,6 +289,9 @@
         "wk:page":"Bamingui-Bangoran"
     },
     "wof:country":"CF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3f6434354bd323d4fdb00466c7ac5f39",
     "wof:hierarchy":[
         {
@@ -306,7 +309,7 @@
         "fra",
         "sag"
     ],
-    "wof:lastmodified":1566637836,
+    "wof:lastmodified":1582347799,
     "wof:name":"Bamingui-Bangoran",
     "wof:parent_id":85632391,
     "wof:placetype":"region",

--- a/data/856/696/93/85669693.geojson
+++ b/data/856/696/93/85669693.geojson
@@ -284,6 +284,9 @@
         "wk:page":"Nana-Gr\u00e9bizi"
     },
     "wof:country":"CF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8d02d12395e0b7abae129f870db2f4b3",
     "wof:hierarchy":[
         {
@@ -301,7 +304,7 @@
         "fra",
         "sag"
     ],
-    "wof:lastmodified":1566637836,
+    "wof:lastmodified":1582347799,
     "wof:name":"Nana-Gribizi",
     "wof:parent_id":85632391,
     "wof:placetype":"region",

--- a/data/856/696/97/85669697.geojson
+++ b/data/856/696/97/85669697.geojson
@@ -290,6 +290,9 @@
         "wk:page":"K\u00e9mo"
     },
     "wof:country":"CF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d791bdbaa6bdf54a3d47500518188589",
     "wof:hierarchy":[
         {
@@ -307,7 +310,7 @@
         "fra",
         "sag"
     ],
-    "wof:lastmodified":1566637839,
+    "wof:lastmodified":1582347800,
     "wof:name":"K\u00e9mo",
     "wof:parent_id":85632391,
     "wof:placetype":"region",

--- a/data/856/696/99/85669699.geojson
+++ b/data/856/696/99/85669699.geojson
@@ -295,6 +295,9 @@
         "wk:page":"Ouaka"
     },
     "wof:country":"CF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2e6114c657e3c3b32c71b2c2fd4b14d3",
     "wof:hierarchy":[
         {
@@ -312,7 +315,7 @@
         "fra",
         "sag"
     ],
-    "wof:lastmodified":1566637838,
+    "wof:lastmodified":1582347800,
     "wof:name":"Ouaka",
     "wof:parent_id":85632391,
     "wof:placetype":"region",

--- a/data/856/697/01/85669701.geojson
+++ b/data/856/697/01/85669701.geojson
@@ -293,6 +293,9 @@
         "wk:page":"Ouham"
     },
     "wof:country":"CF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"41b546f22dbb6bfef83c5460e17d8517",
     "wof:hierarchy":[
         {
@@ -310,7 +313,7 @@
         "fra",
         "sag"
     ],
-    "wof:lastmodified":1566637835,
+    "wof:lastmodified":1582347799,
     "wof:name":"Ouham",
     "wof:parent_id":85632391,
     "wof:placetype":"region",

--- a/data/856/697/03/85669703.geojson
+++ b/data/856/697/03/85669703.geojson
@@ -289,6 +289,9 @@
         "wk:page":"Vakaga"
     },
     "wof:country":"CF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c23ef68d3fa5574ea9a8e43b5814e3b8",
     "wof:hierarchy":[
         {
@@ -306,7 +309,7 @@
         "fra",
         "sag"
     ],
-    "wof:lastmodified":1566637832,
+    "wof:lastmodified":1582347797,
     "wof:name":"Vakaga",
     "wof:parent_id":85632391,
     "wof:placetype":"region",

--- a/data/856/697/05/85669705.geojson
+++ b/data/856/697/05/85669705.geojson
@@ -291,6 +291,9 @@
         "wk:page":"Haute-Kotto"
     },
     "wof:country":"CF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"efa653ba4f91a3eef73339946eb8bdef",
     "wof:hierarchy":[
         {
@@ -308,7 +311,7 @@
         "fra",
         "sag"
     ],
-    "wof:lastmodified":1566637833,
+    "wof:lastmodified":1582347797,
     "wof:name":"Haute-Kotto",
     "wof:parent_id":85632391,
     "wof:placetype":"region",

--- a/data/856/697/07/85669707.geojson
+++ b/data/856/697/07/85669707.geojson
@@ -291,6 +291,9 @@
         "wk:page":"Haut-Mbomou"
     },
     "wof:country":"CF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f5b4bc376b2c0cad24b5e69b470eeb05",
     "wof:hierarchy":[
         {
@@ -308,7 +311,7 @@
         "fra",
         "sag"
     ],
-    "wof:lastmodified":1566637833,
+    "wof:lastmodified":1582347798,
     "wof:name":"Haut-Mbomou",
     "wof:parent_id":85632391,
     "wof:placetype":"region",

--- a/data/856/697/09/85669709.geojson
+++ b/data/856/697/09/85669709.geojson
@@ -287,6 +287,9 @@
         "wk:page":"Mbomou"
     },
     "wof:country":"CF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"158fd9c3de3c09fa651127c12914d080",
     "wof:hierarchy":[
         {
@@ -304,7 +307,7 @@
         "fra",
         "sag"
     ],
-    "wof:lastmodified":1566637834,
+    "wof:lastmodified":1582347798,
     "wof:name":"Mbomou",
     "wof:parent_id":85632391,
     "wof:placetype":"region",

--- a/data/890/449/931/890449931.geojson
+++ b/data/890/449/931/890449931.geojson
@@ -172,6 +172,9 @@
     },
     "wof:country":"CF",
     "wof:created":1469052716,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"7cedbfead93e0f808ff1c58ed20741ed",
     "wof:hierarchy":[
         {
@@ -183,7 +186,7 @@
         }
     ],
     "wof:id":890449931,
-    "wof:lastmodified":1566638245,
+    "wof:lastmodified":1582347807,
     "wof:name":"Zemio",
     "wof:parent_id":1108759587,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.