### PR TITLE
cf concordances, placetype local, and more

### DIFF
--- a/data/110/875/957/9/1108759579.geojson
+++ b/data/110/875/957/9/1108759579.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.995849,
-    "geom:area_square_m":36612858028.863174,
+    "geom:area_square_m":36612859238.176353,
     "geom:bbox":"18.860711,7.336708,22.393709,9.773887",
     "geom:latitude":8.742423,
     "geom:longitude":20.889399,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"CF.BB.ND"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325678,
-    "wof:geomhash":"e6a4344026fdceac99672efe1c7bfac5",
+    "wof:geomhash":"f1526adf3cef91927632729e20d6d448",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1108759579,
-    "wof:lastmodified":1636501618,
+    "wof:lastmodified":1695886790,
     "wof:name":"Ndele",
     "wof:parent_id":85669689,
     "wof:placetype":"county",

--- a/data/110/875/958/3/1108759583.geojson
+++ b/data/110/875/958/3/1108759583.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.969558,
-    "geom:area_square_m":36459982486.816345,
+    "geom:area_square_m":36459982486.81823,
     "geom:bbox":"24.2612843509,5.62219681284,26.5655609243,8.286028",
     "geom:latitude":6.783621,
     "geom:longitude":25.33695,
@@ -75,9 +75,10 @@
     "wof:concordances":{
         "hasc:id":"CF.HM.DJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325680,
-    "wof:geomhash":"0b1e16207f9509a133a52bd12cfcdfb6",
+    "wof:geomhash":"159f97c89cfb367a74a6c91b5da94d1e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1108759583,
-    "wof:lastmodified":1566638132,
+    "wof:lastmodified":1695886301,
     "wof:name":"Djemah",
     "wof:parent_id":85669707,
     "wof:placetype":"county",

--- a/data/110/875/958/5/1108759585.geojson
+++ b/data/110/875/958/5/1108759585.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.584658,
-    "geom:area_square_m":7196078252.055181,
+    "geom:area_square_m":7196078168.571183,
     "geom:bbox":"25.672682,5.046025,26.804842,6.036664",
     "geom:latitude":5.499717,
     "geom:longitude":26.350292,
@@ -126,9 +126,10 @@
     "wof:concordances":{
         "hasc:id":"CF.HM.OB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325681,
-    "wof:geomhash":"7e8cbd93c36e0b4f032c1a51ad1b7c95",
+    "wof:geomhash":"1b31a1f7b57a0a3b281c707b7edf8a38",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108759585,
-    "wof:lastmodified":1636501619,
+    "wof:lastmodified":1695886791,
     "wof:name":"Obo",
     "wof:parent_id":85669707,
     "wof:placetype":"county",

--- a/data/110/875/958/7/1108759587.geojson
+++ b/data/110/875/958/7/1108759587.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.673647,
-    "geom:area_square_m":8292731450.188439,
+    "geom:area_square_m":8292732027.942565,
     "geom:bbox":"24.486364,4.893125,25.982965,5.882739",
     "geom:latitude":5.400469,
     "geom:longitude":25.237456,
@@ -138,9 +138,10 @@
     "wof:concordances":{
         "hasc:id":"CF.HM.ZE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325682,
-    "wof:geomhash":"579287d41f205e30ab8e91a27948fe4f",
+    "wof:geomhash":"5bd9f33059367433abe409274fce184a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -150,7 +151,7 @@
         }
     ],
     "wof:id":1108759587,
-    "wof:lastmodified":1636501619,
+    "wof:lastmodified":1695886791,
     "wof:name":"Zemio",
     "wof:parent_id":85669707,
     "wof:placetype":"county",

--- a/data/110/875/958/9/1108759589.geojson
+++ b/data/110/875/958/9/1108759589.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.100499,
-    "geom:area_square_m":1239067156.17431,
+    "geom:area_square_m":1239067302.734609,
     "geom:bbox":"21.449568,4.225172,22.150751,4.543257",
     "geom:latitude":4.37734,
     "geom:longitude":21.893183,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"CF.BK.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325683,
-    "wof:geomhash":"178baa7ce3c999917df2a23573839948",
+    "wof:geomhash":"0ba2df6629c999af38e57c7aaee25743",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108759589,
-    "wof:lastmodified":1627521988,
+    "wof:lastmodified":1695886460,
     "wof:name":"Satema",
     "wof:parent_id":85669665,
     "wof:placetype":"county",

--- a/data/110/875/959/1/1108759591.geojson
+++ b/data/110/875/959/1/1108759591.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.077515,
-    "geom:area_square_m":956423443.276232,
+    "geom:area_square_m":956423443.276385,
     "geom:bbox":"18.2615597517,3.469993,18.626193,3.95249989612",
     "geom:latitude":3.762448,
     "geom:longitude":18.468995,
@@ -87,9 +87,10 @@
     "wof:concordances":{
         "hasc:id":"CF.LB.MO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325685,
-    "wof:geomhash":"4ce977bf874a0f3e530afd13d345a280",
+    "wof:geomhash":"5b90cae321124886eb7b9dce227475e0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1108759591,
-    "wof:lastmodified":1566638129,
+    "wof:lastmodified":1695886300,
     "wof:name":"Mongoumba",
     "wof:parent_id":85669667,
     "wof:placetype":"county",

--- a/data/110/875/959/3/1108759593.geojson
+++ b/data/110/875/959/3/1108759593.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.228526,
-    "geom:area_square_m":2817441543.042908,
+    "geom:area_square_m":2817441543.042768,
     "geom:bbox":"14.715969,3.995967,15.442951,4.707859",
     "geom:latitude":4.394908,
     "geom:longitude":15.127348,
@@ -96,9 +96,10 @@
     "wof:concordances":{
         "hasc:id":"CF.HS.GA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325686,
-    "wof:geomhash":"bd77b12fd861d7aeced6a5cc789276f7",
+    "wof:geomhash":"4c2d3329da20544347ca1fd8f508a140",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108759593,
-    "wof:lastmodified":1587164333,
+    "wof:lastmodified":1695886292,
     "wof:name":"Gamboula",
     "wof:parent_id":85669671,
     "wof:placetype":"county",

--- a/data/110/875/959/5/1108759595.geojson
+++ b/data/110/875/959/5/1108759595.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.73789,
-    "geom:area_square_m":9077477790.801281,
+    "geom:area_square_m":9077477790.802118,
     "geom:bbox":"14.415098,4.99172131356,15.5411439869,6.62648375529",
     "geom:latitude":5.787152,
     "geom:longitude":14.896118,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"CF.NM.BB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325687,
-    "wof:geomhash":"8904e949edb04762425fb65724d865b8",
+    "wof:geomhash":"7764fdb8e8a7e3637eab3890d202923f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759595,
-    "wof:lastmodified":1566638130,
+    "wof:lastmodified":1695886300,
     "wof:name":"Baboua",
     "wof:parent_id":85669681,
     "wof:placetype":"county",

--- a/data/110/875/959/7/1108759597.geojson
+++ b/data/110/875/959/7/1108759597.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.355796,
-    "geom:area_square_m":4364031934.306805,
+    "geom:area_square_m":4364031934.306945,
     "geom:bbox":"15.1339385683,6.95301561729,16.2266970964,7.618467",
     "geom:latitude":7.277458,
     "geom:longitude":15.661107,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"CF.OP.NG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325688,
-    "wof:geomhash":"f913c7caaa748f0a2a7c15022d65362c",
+    "wof:geomhash":"1514f87039a02785ee88ccf14d2d21d7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759597,
-    "wof:lastmodified":1566638129,
+    "wof:lastmodified":1695886300,
     "wof:name":"Ngaoundaye",
     "wof:parent_id":85669685,
     "wof:placetype":"county",

--- a/data/110/875/960/1/1108759601.geojson
+++ b/data/110/875/960/1/1108759601.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.730435,
-    "geom:area_square_m":8961469152.446964,
+    "geom:area_square_m":8961469152.446932,
     "geom:bbox":"15.9908527784,6.54929775754,16.8363017191,7.885918",
     "geom:latitude":7.156862,
     "geom:longitude":16.42733,
@@ -93,9 +93,10 @@
     "wof:concordances":{
         "hasc:id":"CF.OP.PA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325689,
-    "wof:geomhash":"76fbcc044f0646be418c9a9b593245d3",
+    "wof:geomhash":"52d1b07c09b0c34ae36244e86ec6d69c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108759601,
-    "wof:lastmodified":1566638133,
+    "wof:lastmodified":1695886301,
     "wof:name":"Paoua",
     "wof:parent_id":85669685,
     "wof:placetype":"county",

--- a/data/110/875/960/3/1108759603.geojson
+++ b/data/110/875/960/3/1108759603.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.086886,
-    "geom:area_square_m":1071907821.243454,
+    "geom:area_square_m":1071907821.243493,
     "geom:bbox":"15.073629,3.675451,15.47605,4.057199",
     "geom:latitude":3.882186,
     "geom:longitude":15.287711,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"CF.HS.DM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325691,
-    "wof:geomhash":"4efb372fb0685557b64a88dec3986a43",
+    "wof:geomhash":"3da5c53d3419d2d3e69cdb630165ff37",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759603,
-    "wof:lastmodified":1627521987,
+    "wof:lastmodified":1695886458,
     "wof:name":"Dede-Mokouba",
     "wof:parent_id":85669671,
     "wof:placetype":"county",

--- a/data/110/875/960/5/1108759605.geojson
+++ b/data/110/875/960/5/1108759605.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.320803,
-    "geom:area_square_m":3961745818.808859,
+    "geom:area_square_m":3961745818.808736,
     "geom:bbox":"16.065072,2.223053,16.589535,3.47157755307",
     "geom:latitude":2.875433,
     "geom:longitude":16.307778,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"CF.SE.BY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325692,
-    "wof:geomhash":"c0e5a1ed07fb9dad68e8e5c3a9ce9548",
+    "wof:geomhash":"e9e2d4a079d4bea0eb8cab434fd2177e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759605,
-    "wof:lastmodified":1566638134,
+    "wof:lastmodified":1695886301,
     "wof:name":"Bayanga",
     "wof:parent_id":85669675,
     "wof:placetype":"county",

--- a/data/110/875/960/7/1108759607.geojson
+++ b/data/110/875/960/7/1108759607.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.521241,
-    "geom:area_square_m":6423567890.387552,
+    "geom:area_square_m":6423567801.598679,
     "geom:bbox":"21.737712,4.115013,22.654934,5.090221",
     "geom:latitude":4.694992,
     "geom:longitude":22.195195,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"CF.MB.GA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325693,
-    "wof:geomhash":"7814d4ce8e7598d41ab7bcce4a3e2759",
+    "wof:geomhash":"b663a433d6a9a8b475823a4a64acac11",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1108759607,
-    "wof:lastmodified":1627521987,
+    "wof:lastmodified":1695886458,
     "wof:name":"Gambo",
     "wof:parent_id":85669709,
     "wof:placetype":"county",

--- a/data/110/875/960/9/1108759609.geojson
+++ b/data/110/875/960/9/1108759609.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.098264,
-    "geom:area_square_m":1211421848.16858,
+    "geom:area_square_m":1211421951.037821,
     "geom:bbox":"22.277582,4.115812,22.731749,4.764449",
     "geom:latitude":4.42845,
     "geom:longitude":22.539423,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"CF.MB.OU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325694,
-    "wof:geomhash":"b0da138efe41e5976b5cbcc0050adb44",
+    "wof:geomhash":"db8aa6dbf1c9dc969897b37fc8cadf4e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759609,
-    "wof:lastmodified":1627521988,
+    "wof:lastmodified":1695886460,
     "wof:name":"Ouango",
     "wof:parent_id":85669709,
     "wof:placetype":"county",

--- a/data/110/875/961/1/1108759611.geojson
+++ b/data/110/875/961/1/1108759611.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.374334,
-    "geom:area_square_m":4609567243.236143,
+    "geom:area_square_m":4609567243.236126,
     "geom:bbox":"21.1918262895,4.6683149801,21.9071965057,5.68300703598",
     "geom:latitude":5.209325,
     "geom:longitude":21.591376,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"CF.BK.MI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325695,
-    "wof:geomhash":"eaf6680b32c99aedaf4b69f16f061505",
+    "wof:geomhash":"1da388234a1a83fa101bad4bec014480",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1108759611,
-    "wof:lastmodified":1566638126,
+    "wof:lastmodified":1695886299,
     "wof:name":"Mingala",
     "wof:parent_id":85669665,
     "wof:placetype":"county",

--- a/data/110/875/961/3/1108759613.geojson
+++ b/data/110/875/961/3/1108759613.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.396295,
-    "geom:area_square_m":4880402665.072481,
+    "geom:area_square_m":4880402665.072423,
     "geom:bbox":"20.900501883,4.65788922544,21.5476398124,5.72831739118",
     "geom:latitude":5.152897,
     "geom:longitude":21.196048,
@@ -102,9 +102,10 @@
     "wof:concordances":{
         "hasc:id":"CF.BK.AL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325696,
-    "wof:geomhash":"79a4bb188f7cedb67fb1b648ea68797e",
+    "wof:geomhash":"bbe1814659551955c5cf4340ac907946",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108759613,
-    "wof:lastmodified":1566638126,
+    "wof:lastmodified":1695886299,
     "wof:name":"Alindao",
     "wof:parent_id":85669665,
     "wof:placetype":"county",

--- a/data/110/875/961/5/1108759615.geojson
+++ b/data/110/875/961/5/1108759615.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.122114,
-    "geom:area_square_m":1505312845.153844,
+    "geom:area_square_m":1505312897.406596,
     "geom:bbox":"21.003834,4.281206,21.443602,4.774046",
     "geom:latitude":4.497452,
     "geom:longitude":21.218306,
@@ -135,9 +135,10 @@
     "wof:concordances":{
         "hasc:id":"CF.BK.MO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325697,
-    "wof:geomhash":"f44eceee3fcedf6b053cb345ede1f292",
+    "wof:geomhash":"34f706a29bbce72f79eb5fa10045fcbe",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":1108759615,
-    "wof:lastmodified":1636501618,
+    "wof:lastmodified":1695886790,
     "wof:name":"Mobaye",
     "wof:parent_id":85669665,
     "wof:placetype":"county",

--- a/data/110/875/961/9/1108759619.geojson
+++ b/data/110/875/961/9/1108759619.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.327287,
-    "geom:area_square_m":16297568645.273687,
+    "geom:area_square_m":16297568840.385788,
     "geom:bbox":"21.137743,5.479312,22.667391,7.767574",
     "geom:latitude":6.753692,
     "geom:longitude":22.004152,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"CF.HK.BR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325699,
-    "wof:geomhash":"a3ad462882567bcd637865f9dcd6ae59",
+    "wof:geomhash":"2ebf24030eea5b5bfcaf462130eb93a3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1108759619,
-    "wof:lastmodified":1636501618,
+    "wof:lastmodified":1695886791,
     "wof:name":"Bria",
     "wof:parent_id":85669705,
     "wof:placetype":"county",

--- a/data/110/875/962/1/1108759621.geojson
+++ b/data/110/875/962/1/1108759621.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.224472,
-    "geom:area_square_m":2767580663.849047,
+    "geom:area_square_m":2767580791.347067,
     "geom:bbox":"16.736014,4.017056,17.589753,4.624578",
     "geom:latitude":4.366101,
     "geom:longitude":17.159069,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"CF.LB.BD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325700,
-    "wof:geomhash":"b329057ddf4827fbea1f2669f1acb641",
+    "wof:geomhash":"5349cff9bdab75be773ddf82ce396a35",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759621,
-    "wof:lastmodified":1627521986,
+    "wof:lastmodified":1695886456,
     "wof:name":"Boganda",
     "wof:parent_id":85669667,
     "wof:placetype":"county",

--- a/data/110/875/962/3/1108759623.geojson
+++ b/data/110/875/962/3/1108759623.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.707826,
-    "geom:area_square_m":8730987838.411478,
+    "geom:area_square_m":8730987730.167706,
     "geom:bbox":"17.34871,3.482551,18.496305,4.538273",
     "geom:latitude":4.000867,
     "geom:longitude":17.937838,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"CF.LB.MB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325701,
-    "wof:geomhash":"e5975c317f2f70ed28b673e93d9d8fed",
+    "wof:geomhash":"885af916c2075122f0ce131d2e63ae50",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108759623,
-    "wof:lastmodified":1627521987,
+    "wof:lastmodified":1695886458,
     "wof:name":"M'Baiki",
     "wof:parent_id":85669667,
     "wof:placetype":"county",

--- a/data/110/875/962/5/1108759625.geojson
+++ b/data/110/875/962/5/1108759625.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.070429,
-    "geom:area_square_m":868852096.284708,
+    "geom:area_square_m":868852096.284755,
     "geom:bbox":"15.395241,3.701469,15.802567,4.118263",
     "geom:latitude":3.895197,
     "geom:longitude":15.568308,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"CF.HS.SN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325702,
-    "wof:geomhash":"a842bbf9c5469b931d3dd0f505998690",
+    "wof:geomhash":"4f915f09ac563613ee8347a9e69a4abc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108759625,
-    "wof:lastmodified":1587164333,
+    "wof:lastmodified":1695886292,
     "wof:name":"Sosso-Nakombo",
     "wof:parent_id":85669671,
     "wof:placetype":"county",

--- a/data/110/875/962/7/1108759627.geojson
+++ b/data/110/875/962/7/1108759627.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.596253,
-    "geom:area_square_m":7343869502.420736,
+    "geom:area_square_m":7343870682.06496,
     "geom:bbox":"22.559056,4.575512,23.745765,5.673914",
     "geom:latitude":5.068874,
     "geom:longitude":23.302165,
@@ -147,9 +147,10 @@
     "wof:concordances":{
         "hasc:id":"CF.MB.BN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325703,
-    "wof:geomhash":"9a474413ba208e3fda5633dc8260a4bc",
+    "wof:geomhash":"d916744b299ff5b56ed325a32c552fb3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -159,7 +160,7 @@
         }
     ],
     "wof:id":1108759627,
-    "wof:lastmodified":1636501617,
+    "wof:lastmodified":1695886790,
     "wof:name":"Bangassou",
     "wof:parent_id":85669709,
     "wof:placetype":"county",

--- a/data/110/875/962/9/1108759629.geojson
+++ b/data/110/875/962/9/1108759629.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.172455,
-    "geom:area_square_m":2119922287.285432,
+    "geom:area_square_m":2119922287.285437,
     "geom:bbox":"19.3121589982,5.98766187722,19.8762983779,6.50364022945",
     "geom:latitude":6.21049,
     "geom:longitude":19.631264,
@@ -102,9 +102,10 @@
     "wof:concordances":{
         "hasc:id":"CF.KG.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325704,
-    "wof:geomhash":"7e7c4612ddf939e84e0769476c147f8c",
+    "wof:geomhash":"04cda023fac96bb324d0b89cd805140c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108759629,
-    "wof:lastmodified":1566638115,
+    "wof:lastmodified":1695886296,
     "wof:name":"Mala",
     "wof:parent_id":85669697,
     "wof:placetype":"county",

--- a/data/110/875/963/1/1108759631.geojson
+++ b/data/110/875/963/1/1108759631.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.323297,
-    "geom:area_square_m":16231891039.219936,
+    "geom:area_square_m":16231891039.219837,
     "geom:bbox":"18.6484701327,6.43329821227,19.7866022208,8.56700222402",
     "geom:latitude":7.238223,
     "geom:longitude":19.218165,
@@ -120,9 +120,10 @@
     "wof:concordances":{
         "hasc:id":"CF.KB.KB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325706,
-    "wof:geomhash":"dc80a5e932147725666dacf718c9e79b",
+    "wof:geomhash":"6d29c2e049b670a272eff094468e1eb4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108759631,
-    "wof:lastmodified":1566638118,
+    "wof:lastmodified":1695886297,
     "wof:name":"Kaga-Bandoro",
     "wof:parent_id":85669693,
     "wof:placetype":"county",

--- a/data/110/875/963/3/1108759633.geojson
+++ b/data/110/875/963/3/1108759633.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.286752,
-    "geom:area_square_m":3519497137.209739,
+    "geom:area_square_m":3519497373.105647,
     "geom:bbox":"19.55839,6.44662,20.159784,7.54153",
     "geom:latitude":6.970964,
     "geom:longitude":19.852227,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"CF.KB.MB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325707,
-    "wof:geomhash":"319cf4d17f99754e1660a77b7728892d",
+    "wof:geomhash":"bcee8bfe58591c3d391a4ad69efa296a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759633,
-    "wof:lastmodified":1627521987,
+    "wof:lastmodified":1695886458,
     "wof:name":"Mbres",
     "wof:parent_id":85669693,
     "wof:placetype":"county",

--- a/data/110/875/963/7/1108759637.geojson
+++ b/data/110/875/963/7/1108759637.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.50472,
-    "geom:area_square_m":6219758685.894761,
+    "geom:area_square_m":6219758685.894818,
     "geom:bbox":"15.405299,4.247868,16.874005,5.220673",
     "geom:latitude":4.719736,
     "geom:longitude":16.109128,
@@ -159,9 +159,10 @@
     "wof:concordances":{
         "hasc:id":"CF.HS.CA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325708,
-    "wof:geomhash":"e192fe03bec13b7d40effd3333beabd4",
+    "wof:geomhash":"0650ccf8b51d973a781362da3c6d96ec",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -171,7 +172,7 @@
         }
     ],
     "wof:id":1108759637,
-    "wof:lastmodified":1636501617,
+    "wof:lastmodified":1695886790,
     "wof:name":"Carnot",
     "wof:parent_id":85669671,
     "wof:placetype":"county",

--- a/data/110/875/963/9/1108759639.geojson
+++ b/data/110/875/963/9/1108759639.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.735674,
-    "geom:area_square_m":9047412967.547386,
+    "geom:area_square_m":9047412633.139584,
     "geom:bbox":"14.908296,5.076427,15.939689,6.756808",
     "geom:latitude":5.957608,
     "geom:longitude":15.477759,
@@ -138,9 +138,10 @@
     "wof:concordances":{
         "hasc:id":"CF.NM.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325709,
-    "wof:geomhash":"120ce2a0effc36dae5926637a7c9fe7e",
+    "wof:geomhash":"ab2496802fa62094cd429347018f059b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -150,7 +151,7 @@
         }
     ],
     "wof:id":1108759639,
-    "wof:lastmodified":1636501617,
+    "wof:lastmodified":1695886790,
     "wof:name":"Bouar",
     "wof:parent_id":85669681,
     "wof:placetype":"county",

--- a/data/110/875/964/1/1108759641.geojson
+++ b/data/110/875/964/1/1108759641.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.185594,
-    "geom:area_square_m":2287414907.544718,
+    "geom:area_square_m":2287414907.544448,
     "geom:bbox":"20.4649510204,4.410752,21.0962389683,5.00945513559",
     "geom:latitude":4.628954,
     "geom:longitude":20.82618,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"CF.BK.ZA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325710,
-    "wof:geomhash":"a330210cdefc578f0edb6772b713867e",
+    "wof:geomhash":"98b2e596c7127249c6c6e0fb3a273094",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759641,
-    "wof:lastmodified":1566638119,
+    "wof:lastmodified":1695886297,
     "wof:name":"Zangba",
     "wof:parent_id":85669665,
     "wof:placetype":"county",

--- a/data/110/875/964/3/1108759643.geojson
+++ b/data/110/875/964/3/1108759643.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.603331,
-    "geom:area_square_m":7428770546.819112,
+    "geom:area_square_m":7428770679.405706,
     "geom:bbox":"17.149373,4.508925,18.16984,5.82633",
     "geom:latitude":5.262749,
     "geom:longitude":17.616072,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"CF.MP.BS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325711,
-    "wof:geomhash":"d7082ce5219b3757647d13cabbdb87d1",
+    "wof:geomhash":"ddb45944c9adb3c573f44980f97afe88",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759643,
-    "wof:lastmodified":1627521986,
+    "wof:lastmodified":1695886456,
     "wof:name":"Bossembele",
     "wof:parent_id":85669661,
     "wof:placetype":"county",

--- a/data/110/875/964/5/1108759645.geojson
+++ b/data/110/875/964/5/1108759645.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.39164,
-    "geom:area_square_m":4817738205.471536,
+    "geom:area_square_m":4817738481.407495,
     "geom:bbox":"18.609339,5.540998,19.681091,6.132458",
     "geom:latitude":5.820007,
     "geom:longitude":19.142359,
@@ -120,9 +120,10 @@
     "wof:concordances":{
         "hasc:id":"CF.KG.SI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325712,
-    "wof:geomhash":"23edaf14ccc993d696806306dd7aa6e9",
+    "wof:geomhash":"d8ad0423a8e5c88176c37ac36b6e2d16",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1108759645,
-    "wof:lastmodified":1636501617,
+    "wof:lastmodified":1695886790,
     "wof:name":"Sibut",
     "wof:parent_id":85669697,
     "wof:placetype":"county",

--- a/data/110/875/964/7/1108759647.geojson
+++ b/data/110/875/964/7/1108759647.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.558369,
-    "geom:area_square_m":6877441533.064623,
+    "geom:area_square_m":6877441533.064962,
     "geom:bbox":"18.2579059231,4.50133052948,19.1416755336,5.73703898282",
     "geom:latitude":5.05182,
     "geom:longitude":18.720507,
@@ -90,9 +90,10 @@
     "wof:concordances":{
         "hasc:id":"CF.MP.DA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325714,
-    "wof:geomhash":"2e18d65176162c1a98e087e027f3e6da",
+    "wof:geomhash":"c50c7e52bec64f6182f2ef32b61a1e99",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108759647,
-    "wof:lastmodified":1566638119,
+    "wof:lastmodified":1695886297,
     "wof:name":"Damara",
     "wof:parent_id":85669661,
     "wof:placetype":"county",

--- a/data/110/875/964/9/1108759649.geojson
+++ b/data/110/875/964/9/1108759649.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.242848,
-    "geom:area_square_m":2992601432.385333,
+    "geom:area_square_m":2992601432.385471,
     "geom:bbox":"16.8285024823,4.36398066257,17.5487766769,5.02467418209",
     "geom:latitude":4.735661,
     "geom:longitude":17.140498,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"CF.LB.BG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325715,
-    "wof:geomhash":"89a327564ab399177fd4b5a2f50be7b2",
+    "wof:geomhash":"5f09f58afb6427fba9be515785f51bb1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1108759649,
-    "wof:lastmodified":1566638118,
+    "wof:lastmodified":1695886297,
     "wof:name":"Boganangone",
     "wof:parent_id":85669667,
     "wof:placetype":"county",

--- a/data/110/875/965/1/1108759651.geojson
+++ b/data/110/875/965/1/1108759651.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.396508,
-    "geom:area_square_m":4880814547.917877,
+    "geom:area_square_m":4880814547.917896,
     "geom:bbox":"16.4895147911,4.91558409494,17.4096464743,5.86011091105",
     "geom:latitude":5.435954,
     "geom:longitude":16.982689,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"CF.MP.YA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325716,
-    "wof:geomhash":"7187a44b62a68a6d6d1d65ffe3819448",
+    "wof:geomhash":"ca799b73fbae66e0dc494fc5ed72da63",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1108759651,
-    "wof:lastmodified":1566638115,
+    "wof:lastmodified":1695886296,
     "wof:name":"Yaloke",
     "wof:parent_id":85669661,
     "wof:placetype":"county",

--- a/data/110/875/965/5/1108759655.geojson
+++ b/data/110/875/965/5/1108759655.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.934772,
-    "geom:area_square_m":11482646859.796642,
+    "geom:area_square_m":11482646859.796894,
     "geom:bbox":"19.7372990947,5.87828954527,21.0438127279,7.33529993557",
     "geom:latitude":6.565175,
     "geom:longitude":20.392323,
@@ -75,9 +75,10 @@
     "wof:concordances":{
         "hasc:id":"CF.UK.BK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325717,
-    "wof:geomhash":"efa8bebbd733202111ba7adde8284536",
+    "wof:geomhash":"b2217a258eb302f6bbb4557205056b67",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1108759655,
-    "wof:lastmodified":1566638115,
+    "wof:lastmodified":1695886296,
     "wof:name":"Bakala",
     "wof:parent_id":85669699,
     "wof:placetype":"county",

--- a/data/110/875/965/7/1108759657.geojson
+++ b/data/110/875/965/7/1108759657.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.411209,
-    "geom:area_square_m":5058865715.619796,
+    "geom:area_square_m":5058865715.619853,
     "geom:bbox":"19.4644994431,5.37205179805,20.3530949775,6.15931209099",
     "geom:latitude":5.773012,
     "geom:longitude":19.956955,
@@ -84,9 +84,10 @@
     "wof:concordances":{
         "hasc:id":"CF.UK.GR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325718,
-    "wof:geomhash":"b7c186e8c159e1e96072ea00c1000141",
+    "wof:geomhash":"e55bcb2824775db6a0eb1c0ca8ae0dfd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1108759657,
-    "wof:lastmodified":1566638114,
+    "wof:lastmodified":1695886296,
     "wof:name":"Grimari",
     "wof:parent_id":85669699,
     "wof:placetype":"county",

--- a/data/110/875/965/9/1108759659.geojson
+++ b/data/110/875/965/9/1108759659.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.399896,
-    "geom:area_square_m":17194792985.07761,
+    "geom:area_square_m":17194792985.077816,
     "geom:bbox":"20.656759744,5.71404524599,21.9444640883,7.70529823469",
     "geom:latitude":6.597438,
     "geom:longitude":21.285002,
@@ -93,9 +93,10 @@
     "wof:concordances":{
         "hasc:id":"CF.UK.IP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325721,
-    "wof:geomhash":"a12608ac64a8ef6cfdff51a900c78a7f",
+    "wof:geomhash":"14160200f11035b70438f34d97344ab2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108759659,
-    "wof:lastmodified":1566638114,
+    "wof:lastmodified":1695886296,
     "wof:name":"Ippy",
     "wof:parent_id":85669699,
     "wof:placetype":"county",

--- a/data/110/875/966/1/1108759661.geojson
+++ b/data/110/875/966/1/1108759661.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.33722,
-    "geom:area_square_m":28617612742.265419,
+    "geom:area_square_m":28617611718.825169,
     "geom:bbox":"21.101907,6.888561,23.561871,9.240841",
     "geom:latitude":8.008445,
     "geom:longitude":22.4841,
@@ -132,9 +132,10 @@
     "wof:concordances":{
         "hasc:id":"CF.HK.OU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325723,
-    "wof:geomhash":"db11e7233340ada701e36bd43aecdcaf",
+    "wof:geomhash":"4cb049769731739754145f1680cb6b04",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":1108759661,
-    "wof:lastmodified":1636501618,
+    "wof:lastmodified":1695886791,
     "wof:name":"Ouadda",
     "wof:parent_id":85669705,
     "wof:placetype":"county",

--- a/data/110/875/966/3/1108759663.geojson
+++ b/data/110/875/966/3/1108759663.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.611408,
-    "geom:area_square_m":7530414214.880427,
+    "geom:area_square_m":7530414214.880548,
     "geom:bbox":"19.853619,4.53038700272,20.9636704643,5.60017727645",
     "geom:latitude":5.081839,
     "geom:longitude":20.432039,
@@ -84,9 +84,10 @@
     "wof:concordances":{
         "hasc:id":"CF.UK.KO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325724,
-    "wof:geomhash":"7126384836e695981a91425215f55aff",
+    "wof:geomhash":"87204bfc3bb8268395f8ce9586ca459b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1108759663,
-    "wof:lastmodified":1566638128,
+    "wof:lastmodified":1695886299,
     "wof:name":"Kouango",
     "wof:parent_id":85669699,
     "wof:placetype":"county",

--- a/data/110/875/966/5/1108759665.geojson
+++ b/data/110/875/966/5/1108759665.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.43372,
-    "geom:area_square_m":5338657913.524757,
+    "geom:area_square_m":5338657913.524824,
     "geom:bbox":"15.763547427,5.06987333601,16.5262862743,5.91253589306",
     "geom:latitude":5.461191,
     "geom:longitude":16.140799,
@@ -93,9 +93,10 @@
     "wof:concordances":{
         "hasc:id":"CF.NM.BR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325725,
-    "wof:geomhash":"96109855b431f3d8c7b7cc24129fff4e",
+    "wof:geomhash":"5c46b788ae9aafe912dded632d97ab2e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108759665,
-    "wof:lastmodified":1566638128,
+    "wof:lastmodified":1695886299,
     "wof:name":"Baoro",
     "wof:parent_id":85669681,
     "wof:placetype":"county",

--- a/data/110/875/966/7/1108759667.geojson
+++ b/data/110/875/966/7/1108759667.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.299136,
-    "geom:area_square_m":3678941691.474253,
+    "geom:area_square_m":3678941718.481844,
     "geom:bbox":"16.187501,5.55595,16.974392,6.31836",
     "geom:latitude":5.948415,
     "geom:longitude":16.541812,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"CF.OP.BT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325726,
-    "wof:geomhash":"425b564e72498e634197cb8f2d962723",
+    "wof:geomhash":"9ee255630171c22f922ecb679eddf769",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108759667,
-    "wof:lastmodified":1627521987,
+    "wof:lastmodified":1695886459,
     "wof:name":"Bossemptele",
     "wof:parent_id":85669685,
     "wof:placetype":"county",

--- a/data/110/875/966/9/1108759669.geojson
+++ b/data/110/875/966/9/1108759669.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.392958,
-    "geom:area_square_m":4836487839.138014,
+    "geom:area_square_m":4836487839.13806,
     "geom:bbox":"17.7864125986,5.05300873747,18.6898217546,5.90755673848",
     "geom:latitude":5.514257,
     "geom:longitude":18.209993,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"CF.MP.BG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325727,
-    "wof:geomhash":"a37e474b96c6737853d13903bc1b8412",
+    "wof:geomhash":"de487b4e13069534e69b508dfdfaeb1b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1108759669,
-    "wof:lastmodified":1566638127,
+    "wof:lastmodified":1695886299,
     "wof:name":"Bogangolo",
     "wof:parent_id":85669661,
     "wof:placetype":"county",

--- a/data/110/875/967/3/1108759673.geojson
+++ b/data/110/875/967/3/1108759673.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.957995,
-    "geom:area_square_m":11773373349.34166,
+    "geom:area_square_m":11773372869.541288,
     "geom:bbox":"16.723395,5.710894,17.963457,6.976597",
     "geom:latitude":6.329234,
     "geom:longitude":17.339045,
@@ -141,9 +141,10 @@
     "wof:concordances":{
         "hasc:id":"CF.AC.BS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325729,
-    "wof:geomhash":"da6ad2864eeedf76d341698d332dc9d6",
+    "wof:geomhash":"3ea713dc5588f742534ce3741d57c89f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -153,7 +154,7 @@
         }
     ],
     "wof:id":1108759673,
-    "wof:lastmodified":1636501619,
+    "wof:lastmodified":1695886792,
     "wof:name":"Bossangoa",
     "wof:parent_id":85669701,
     "wof:placetype":"county",

--- a/data/110/875/967/5/1108759675.geojson
+++ b/data/110/875/967/5/1108759675.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.701915,
-    "geom:area_square_m":8598932103.330462,
+    "geom:area_square_m":8598932103.330347,
     "geom:bbox":"17.9111099437,7.08660330517,19.0758187864,8.57392980347",
     "geom:latitude":7.798408,
     "geom:longitude":18.585446,
@@ -93,9 +93,10 @@
     "wof:concordances":{
         "hasc:id":"CF.AC.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325730,
-    "wof:geomhash":"5c024c0deeb69faca3f6f00942737267",
+    "wof:geomhash":"fdc5966caf7b136af203d9a19856e1cf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108759675,
-    "wof:lastmodified":1566638131,
+    "wof:lastmodified":1695886301,
     "wof:name":"Kabo",
     "wof:parent_id":85669701,
     "wof:placetype":"county",

--- a/data/110/875/967/7/1108759677.geojson
+++ b/data/110/875/967/7/1108759677.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.367758,
-    "geom:area_square_m":4508131944.103167,
+    "geom:area_square_m":4508131944.102918,
     "geom:bbox":"16.8030711961,7.19086302588,17.7289398975,7.986357",
     "geom:latitude":7.533371,
     "geom:longitude":17.256435,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"CF.AC.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325731,
-    "wof:geomhash":"6ff56fc56e35039dcec4fcff66512ab0",
+    "wof:geomhash":"85525fb84c921c06023d5ec2a3d02266",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1108759677,
-    "wof:lastmodified":1566638131,
+    "wof:lastmodified":1695886301,
     "wof:name":"Markounda",
     "wof:parent_id":85669701,
     "wof:placetype":"county",

--- a/data/110/875/967/9/1108759679.geojson
+++ b/data/110/875/967/9/1108759679.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.466746,
-    "geom:area_square_m":5758650952.782116,
+    "geom:area_square_m":5758650952.782089,
     "geom:bbox":"16.2562768707,3.49638075992,17.3730909571,4.25979801813",
     "geom:latitude":3.806138,
     "geom:longitude":16.787453,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"CF.SE.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325732,
-    "wof:geomhash":"88cd21a22da73db2f2b74f89117d5f99",
+    "wof:geomhash":"7d0136236579477a9ec957ec83891c6e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1108759679,
-    "wof:lastmodified":1566638130,
+    "wof:lastmodified":1695886300,
     "wof:name":"Bambio",
     "wof:parent_id":85669675,
     "wof:placetype":"county",

--- a/data/110/875/968/1/1108759681.geojson
+++ b/data/110/875/968/1/1108759681.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.255698,
-    "geom:area_square_m":3150566590.354919,
+    "geom:area_square_m":3150566590.35487,
     "geom:bbox":"14.673963,4.606682,15.566134,5.01806",
     "geom:latitude":4.821986,
     "geom:longitude":15.102231,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"CF.HS.AG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325733,
-    "wof:geomhash":"b7a3fb592e301c80e936cc4696cc014d",
+    "wof:geomhash":"fe6b92873873dfd9fa147b8271fe4f17",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759681,
-    "wof:lastmodified":1587164333,
+    "wof:lastmodified":1695886292,
     "wof:name":"Amada-Gaza",
     "wof:parent_id":85669671,
     "wof:placetype":"county",

--- a/data/110/875/968/3/1108759683.geojson
+++ b/data/110/875/968/3/1108759683.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.735572,
-    "geom:area_square_m":9069925555.015907,
+    "geom:area_square_m":9069925555.01601,
     "geom:bbox":"15.254329,3.825095,16.666017,4.763985",
     "geom:latitude":4.291739,
     "geom:longitude":15.895548,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"CF.HS.BE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325734,
-    "wof:geomhash":"39d86d1c39d1ab98601cb31082d5f0fd",
+    "wof:geomhash":"c340013a3b659307e31d855bbfddd36b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759683,
-    "wof:lastmodified":1627521986,
+    "wof:lastmodified":1695886456,
     "wof:name":"Berberati",
     "wof:parent_id":85669671,
     "wof:placetype":"county",

--- a/data/110/875/968/5/1108759685.geojson
+++ b/data/110/875/968/5/1108759685.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.318888,
-    "geom:area_square_m":3926710017.384562,
+    "geom:area_square_m":3926710228.487877,
     "geom:bbox":"14.846869,4.940694,15.698079,5.623944",
     "geom:latitude":5.225505,
     "geom:longitude":15.217998,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"CF.NM.AB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325736,
-    "wof:geomhash":"06d16fda2a14380e20b5bec5a0269a44",
+    "wof:geomhash":"7e20b6b285f655e2a65bacd95fa223f5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759685,
-    "wof:lastmodified":1627521986,
+    "wof:lastmodified":1695886457,
     "wof:name":"Abba",
     "wof:parent_id":85669681,
     "wof:placetype":"county",

--- a/data/110/875/968/7/1108759687.geojson
+++ b/data/110/875/968/7/1108759687.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.388167,
-    "geom:area_square_m":4783038241.228763,
+    "geom:area_square_m":4783038241.228636,
     "geom:bbox":"17.6362519148,4.43658434042,18.4368304384,5.19729905072",
     "geom:latitude":4.780701,
     "geom:longitude":18.034244,
@@ -75,9 +75,10 @@
     "wof:concordances":{
         "hasc:id":"CF.MP.BL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325737,
-    "wof:geomhash":"8cadee332d83b013e6925cbcbec2e04b",
+    "wof:geomhash":"01bf1eca862655dde8bc664df95bed12",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1108759687,
-    "wof:lastmodified":1566638125,
+    "wof:lastmodified":1695886299,
     "wof:name":"Boali",
     "wof:parent_id":85669661,
     "wof:placetype":"county",

--- a/data/110/875/969/1/1108759691.geojson
+++ b/data/110/875/969/1/1108759691.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.638376,
-    "geom:area_square_m":7846171016.519926,
+    "geom:area_square_m":7846171192.374982,
     "geom:bbox":"15.703011,5.787331,17.131125,6.669375",
     "geom:latitude":6.284137,
     "geom:longitude":16.347751,
@@ -123,9 +123,10 @@
     "wof:concordances":{
         "hasc:id":"CF.OP.BU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325738,
-    "wof:geomhash":"9be752e7afe9c9cc05663b795f1e6a2a",
+    "wof:geomhash":"706e79ad26b3782fa37f4ebf7719a87c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108759691,
-    "wof:lastmodified":1636501620,
+    "wof:lastmodified":1695886792,
     "wof:name":"Bozoum",
     "wof:parent_id":85669685,
     "wof:placetype":"county",

--- a/data/110/875/969/3/1108759693.geojson
+++ b/data/110/875/969/3/1108759693.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.769675,
-    "geom:area_square_m":9438983543.981958,
+    "geom:area_square_m":9438983543.981903,
     "geom:bbox":"17.4091020505,6.85074760571,18.7471130895,7.97841667197",
     "geom:latitude":7.345511,
     "geom:longitude":17.960568,
@@ -99,9 +99,10 @@
     "wof:concordances":{
         "hasc:id":"CF.AC.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325740,
-    "wof:geomhash":"27354e29d254917cfe970cf88ee13fe5",
+    "wof:geomhash":"dc36930e4d3e0bc24a2c743039bf8daf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108759693,
-    "wof:lastmodified":1566638135,
+    "wof:lastmodified":1695886302,
     "wof:name":"Batangafo",
     "wof:parent_id":85669701,
     "wof:placetype":"county",

--- a/data/110/875/969/5/1108759695.geojson
+++ b/data/110/875/969/5/1108759695.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.19349,
-    "geom:area_square_m":14666282381.215878,
+    "geom:area_square_m":14666282381.215672,
     "geom:bbox":"17.608479589,5.56037617058,18.9136976004,7.11628702624",
     "geom:latitude":6.372838,
     "geom:longitude":18.286718,
@@ -90,9 +90,10 @@
     "wof:concordances":{
         "hasc:id":"CF.AC.BC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325742,
-    "wof:geomhash":"58182f628c4c3dab9678c92694f40ad0",
+    "wof:geomhash":"a8f392a566a7071bf47c1a4156e4bd3f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108759695,
-    "wof:lastmodified":1566638135,
+    "wof:lastmodified":1695886302,
     "wof:name":"Bouca",
     "wof:parent_id":85669701,
     "wof:placetype":"county",

--- a/data/110/875/969/7/1108759697.geojson
+++ b/data/110/875/969/7/1108759697.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.161535,
-    "geom:area_square_m":1982630400.858999,
+    "geom:area_square_m":1982630400.859034,
     "geom:bbox":"17.1516819172,6.51288663564,17.647162943,7.34527900171",
     "geom:latitude":6.971816,
     "geom:longitude":17.379411,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"CF.AC.NK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325743,
-    "wof:geomhash":"b6e2c93ac75fd90e74b9ef4bf2eb717c",
+    "wof:geomhash":"ce339834e913e62b951028b564234acc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759697,
-    "wof:lastmodified":1566638134,
+    "wof:lastmodified":1695886302,
     "wof:name":"Nana-Bakassa",
     "wof:parent_id":85669701,
     "wof:placetype":"county",

--- a/data/110/875/969/9/1108759699.geojson
+++ b/data/110/875/969/9/1108759699.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.175775,
-    "geom:area_square_m":2156994702.773023,
+    "geom:area_square_m":2156994948.174746,
     "geom:bbox":"16.676987,6.772748,17.212944,7.448353",
     "geom:latitude":7.0637,
     "geom:longitude":16.919499,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"CF.AC.NG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325744,
-    "wof:geomhash":"e716849d2fdaf2ce1bcf35885972a56c",
+    "wof:geomhash":"e1b7863415da0b9622bde3e32f6f828b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108759699,
-    "wof:lastmodified":1627521987,
+    "wof:lastmodified":1695886459,
     "wof:name":"Nanga-Boguila",
     "wof:parent_id":85669701,
     "wof:placetype":"county",

--- a/data/110/875/970/1/1108759701.geojson
+++ b/data/110/875/970/1/1108759701.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.386436,
-    "geom:area_square_m":4756619364.250898,
+    "geom:area_square_m":4756618624.521536,
     "geom:bbox":"26.656352,5.018002,27.458305,5.992763",
     "geom:latitude":5.463664,
     "geom:longitude":26.974876,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"CF.HM.MB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325745,
-    "wof:geomhash":"266d286e0f4af2b84df7c69b49562d05",
+    "wof:geomhash":"183a7c8d4d1e696766b4deda46107346",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759701,
-    "wof:lastmodified":1627521986,
+    "wof:lastmodified":1695886457,
     "wof:name":"Bambouti",
     "wof:parent_id":85669707,
     "wof:placetype":"county",

--- a/data/110/875/970/3/1108759703.geojson
+++ b/data/110/875/970/3/1108759703.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.3814,
-    "geom:area_square_m":41462670261.586281,
+    "geom:area_square_m":41462670261.58786,
     "geom:bbox":"22.2599897911,6.08261348901,24.5889596953,9.24150831354",
     "geom:latitude":7.376552,
     "geom:longitude":23.585641,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"CF.HK.YA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325746,
-    "wof:geomhash":"20825915371df14d0ee36eab194d579a",
+    "wof:geomhash":"c2d5ffc54d53325089aa92c21af2999a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1108759703,
-    "wof:lastmodified":1566638121,
+    "wof:lastmodified":1695886297,
     "wof:name":"Yalinga",
     "wof:parent_id":85669705,
     "wof:placetype":"county",

--- a/data/110/875/970/5/1108759705.geojson
+++ b/data/110/875/970/5/1108759705.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.250038,
-    "geom:area_square_m":27678399377.603889,
+    "geom:area_square_m":27678398870.987568,
     "geom:bbox":"23.271854,4.757582,25.189555,6.752035",
     "geom:latitude":5.810377,
     "geom:longitude":24.203041,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"CF.MB.RA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325748,
-    "wof:geomhash":"def4fc4a6d92d3bdd693a58c541d25b2",
+    "wof:geomhash":"1519cfe48101d60358ed523e6b6e435a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108759705,
-    "wof:lastmodified":1627521988,
+    "wof:lastmodified":1695886460,
     "wof:name":"Rafai",
     "wof:parent_id":85669709,
     "wof:placetype":"county",

--- a/data/110/875/970/9/1108759709.geojson
+++ b/data/110/875/970/9/1108759709.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.204184,
-    "geom:area_square_m":2507442035.711986,
+    "geom:area_square_m":2507442035.711747,
     "geom:bbox":"14.9418196607,6.29616210375,15.5983896287,7.04673394664",
     "geom:latitude":6.715051,
     "geom:longitude":15.348075,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"CF.OP.KI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325750,
-    "wof:geomhash":"a2544fe7582565dba56d9119a6a7af7d",
+    "wof:geomhash":"9be6e62af6ff7ad355db5cb054e3947c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759709,
-    "wof:lastmodified":1566638120,
+    "wof:lastmodified":1695886297,
     "wof:name":"Koui",
     "wof:parent_id":85669685,
     "wof:placetype":"county",

--- a/data/110/875/971/1/1108759711.geojson
+++ b/data/110/875/971/1/1108759711.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.716969,
-    "geom:area_square_m":8848857660.250824,
+    "geom:area_square_m":8848857660.250635,
     "geom:bbox":"15.2840317478,2.70444423542,16.6045933838,4.00152377885",
     "geom:latitude":3.502173,
     "geom:longitude":15.96786,
@@ -207,9 +207,10 @@
     "wof:concordances":{
         "hasc:id":"CF.SE.NO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325751,
-    "wof:geomhash":"388cfb1257e2b287dd640aaccd35e17c",
+    "wof:geomhash":"ece66093248a0f67af8556b1ddbf93e9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -219,7 +220,7 @@
         }
     ],
     "wof:id":1108759711,
-    "wof:lastmodified":1566638123,
+    "wof:lastmodified":1695886298,
     "wof:name":"Nola",
     "wof:parent_id":85669675,
     "wof:placetype":"county",

--- a/data/110/875/971/3/1108759713.geojson
+++ b/data/110/875/971/3/1108759713.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.129567,
-    "geom:area_square_m":38107340544.640152,
+    "geom:area_square_m":38107340290.660133,
     "geom:bbox":"20.817173,8.982316,23.696254,11.017957",
     "geom:latitude":10.007263,
     "geom:longitude":22.531222,
@@ -117,9 +117,10 @@
     "wof:concordances":{
         "hasc:id":"CF.VK.BI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325753,
-    "wof:geomhash":"4a5310b9275731689df35906c1d07c06",
+    "wof:geomhash":"bc47df5a2836d8a0505f6b506be86dc1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108759713,
-    "wof:lastmodified":1636501618,
+    "wof:lastmodified":1695886791,
     "wof:name":"Birao",
     "wof:parent_id":85669703,
     "wof:placetype":"county",

--- a/data/110/875/971/5/1108759715.geojson
+++ b/data/110/875/971/5/1108759715.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.428959,
-    "geom:area_square_m":17585492243.129295,
+    "geom:area_square_m":17585492243.129154,
     "geom:bbox":"21.7937343487,4.84923651385,23.3753831817,6.2735888663",
     "geom:latitude":5.575028,
     "geom:longitude":22.645955,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"CF.MB.BK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325754,
-    "wof:geomhash":"3085141b53f0a5b037a8e3753da5507b",
+    "wof:geomhash":"a9c348c418c5f70e23ef44becc685142",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1108759715,
-    "wof:lastmodified":1566638124,
+    "wof:lastmodified":1695886298,
     "wof:name":"Bakouma",
     "wof:parent_id":85669709,
     "wof:placetype":"county",

--- a/data/110/875/971/7/1108759717.geojson
+++ b/data/110/875/971/7/1108759717.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.523883,
-    "geom:area_square_m":6453546554.142626,
+    "geom:area_square_m":6453546554.142798,
     "geom:bbox":"16.083508,4.337207,17.121381,5.390393",
     "geom:latitude":4.966202,
     "geom:longitude":16.643964,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"CF.HS.GZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325755,
-    "wof:geomhash":"e7603bd05eccd9817b5d92833295438e",
+    "wof:geomhash":"a655f405db521703b6830010b317fa83",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759717,
-    "wof:lastmodified":1627521987,
+    "wof:lastmodified":1695886459,
     "wof:name":"Gadzi",
     "wof:parent_id":85669671,
     "wof:placetype":"county",

--- a/data/110/875/971/9/1108759719.geojson
+++ b/data/110/875/971/9/1108759719.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.303084,
-    "geom:area_square_m":3725225609.516532,
+    "geom:area_square_m":3725225609.516629,
     "geom:bbox":"18.7399114552,5.99310114255,19.5595681768,6.55379969478",
     "geom:latitude":6.275728,
     "geom:longitude":19.14904,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"CF.KG.DE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325761,
-    "wof:geomhash":"22899153818076129f2c3b0dcb3fe52c",
+    "wof:geomhash":"b0d312e6395994ecbe47b07c640f4418",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1108759719,
-    "wof:lastmodified":1566638122,
+    "wof:lastmodified":1695886298,
     "wof:name":"Dekoa",
     "wof:parent_id":85669697,
     "wof:placetype":"county",

--- a/data/110/875/972/1/1108759721.geojson
+++ b/data/110/875/972/1/1108759721.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.374771,
-    "geom:area_square_m":4601826831.583937,
+    "geom:area_square_m":4601826831.584112,
     "geom:bbox":"15.4590915145,6.34652477618,16.1369525689,7.16651857086",
     "geom:latitude":6.765566,
     "geom:longitude":15.778644,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"CF.OP.BC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325762,
-    "wof:geomhash":"070fa8894359e42c97ad6765d1a642f5",
+    "wof:geomhash":"c8738644f0a4bbbc15ddf3f1e16ea98e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1108759721,
-    "wof:lastmodified":1566638138,
+    "wof:lastmodified":1695886302,
     "wof:name":"Bocaranga",
     "wof:parent_id":85669685,
     "wof:placetype":"county",

--- a/data/110/875/972/3/1108759723.geojson
+++ b/data/110/875/972/3/1108759723.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.478159,
-    "geom:area_square_m":5886891536.153162,
+    "geom:area_square_m":5886891984.678593,
     "geom:bbox":"18.855969,4.938316,20.017423,5.709681",
     "geom:latitude":5.334929,
     "geom:longitude":19.397485,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"CF.KG.ND"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325763,
-    "wof:geomhash":"acc728bf556c3dd44de98aab17535ac1",
+    "wof:geomhash":"114fd36e7c0e18f30e5a77e893762404",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759723,
-    "wof:lastmodified":1627521988,
+    "wof:lastmodified":1695886460,
     "wof:name":"Ndjoukou",
     "wof:parent_id":85669697,
     "wof:placetype":"county",

--- a/data/110/875/972/7/1108759727.geojson
+++ b/data/110/875/972/7/1108759727.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.253763,
-    "geom:area_square_m":3129898536.280919,
+    "geom:area_square_m":3129898536.280942,
     "geom:bbox":"16.9140902258,3.7494516079,17.6843137463,4.37310828385",
     "geom:latitude":4.072798,
     "geom:longitude":17.317,
@@ -102,9 +102,10 @@
     "wof:concordances":{
         "hasc:id":"CF.LB.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325765,
-    "wof:geomhash":"48746172694586c5bb029aec63613d6f",
+    "wof:geomhash":"acd3154889dce57df06579b536e9b4f9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108759727,
-    "wof:lastmodified":1566638137,
+    "wof:lastmodified":1695886302,
     "wof:name":"Boda",
     "wof:parent_id":85669667,
     "wof:placetype":"county",

--- a/data/110/875/972/9/1108759729.geojson
+++ b/data/110/875/972/9/1108759729.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.650501,
-    "geom:area_square_m":8003709767.519112,
+    "geom:area_square_m":8003709531.712789,
     "geom:bbox":"20.240633,5.267183,21.941992,6.227916",
     "geom:latitude":5.703655,
     "geom:longitude":20.913065,
@@ -156,9 +156,10 @@
     "wof:concordances":{
         "hasc:id":"CF.UK.BM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325766,
-    "wof:geomhash":"9f5ef5837f11861535906f1209052802",
+    "wof:geomhash":"5df7164280db4beae23c814035c88094",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -168,7 +169,7 @@
         }
     ],
     "wof:id":1108759729,
-    "wof:lastmodified":1636501620,
+    "wof:lastmodified":1695886792,
     "wof:name":"Bambari",
     "wof:parent_id":85669699,
     "wof:placetype":"county",

--- a/data/110/875/973/1/1108759731.geojson
+++ b/data/110/875/973/1/1108759731.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.73399,
-    "geom:area_square_m":8962664890.48151,
+    "geom:area_square_m":8962664582.160046,
     "geom:bbox":"21.670772,8.579844,23.198195,9.556579",
     "geom:latitude":9.058533,
     "geom:longitude":22.427515,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"CF.VK.OU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325767,
-    "wof:geomhash":"852d1c80348d875906ecd883f8a794c7",
+    "wof:geomhash":"03485524befc849960c60993ef2afaae",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108759731,
-    "wof:lastmodified":1627521988,
+    "wof:lastmodified":1695886461,
     "wof:name":"Ouanda Djalle",
     "wof:parent_id":85669703,
     "wof:placetype":"county",

--- a/data/110/875/973/3/1108759733.geojson
+++ b/data/110/875/973/3/1108759733.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.256259,
-    "geom:area_square_m":3159612867.361206,
+    "geom:area_square_m":3159612867.36105,
     "geom:bbox":"18.1202916151,3.87129917117,18.8256986223,4.67258449164",
     "geom:latitude":4.33385,
     "geom:longitude":18.46897,
@@ -87,9 +87,10 @@
     "wof:concordances":{
         "hasc:id":"CF.MP.BI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325769,
-    "wof:geomhash":"167abb217db9ddf1ddbab3e0a258bb95",
+    "wof:geomhash":"1671ca03190609c07e2e59f6b8e86e7b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1108759733,
-    "wof:lastmodified":1566638137,
+    "wof:lastmodified":1695886302,
     "wof:name":"Bimbo",
     "wof:parent_id":85669661,
     "wof:placetype":"county",

--- a/data/110/875/973/5/1108759735.geojson
+++ b/data/110/875/973/5/1108759735.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005709,
-    "geom:area_square_m":70388792.873709,
+    "geom:area_square_m":70388792.873705,
     "geom:bbox":"18.524309,4.322539,18.644218,4.431223",
     "geom:latitude":4.379529,
     "geom:longitude":18.565811,
@@ -402,12 +402,13 @@
     "wof:concordances":{
         "hasc:id":"CF.BG.BG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         421181445
     ],
     "wof:country":"CF",
     "wof:created":1481325769,
-    "wof:geomhash":"1dbc2a2aaad41cdee65bd1169f3ba878",
+    "wof:geomhash":"e883966dc6695019058b8aa4c00e76f3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -417,7 +418,7 @@
         }
     ],
     "wof:id":1108759735,
-    "wof:lastmodified":1607982164,
+    "wof:lastmodified":1695886404,
     "wof:name":"Bangui",
     "wof:parent_id":85669655,
     "wof:placetype":"county",

--- a/data/110/875/973/7/1108759737.geojson
+++ b/data/110/875/973/7/1108759737.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.185721,
-    "geom:area_square_m":2289258121.325719,
+    "geom:area_square_m":2289257518.096568,
     "geom:bbox":"21.289479,4.280726,21.955598,4.791555",
     "geom:latitude":4.543974,
     "geom:longitude":21.595023,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"CF.BK.KE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1481325770,
-    "wof:geomhash":"6c9896f15ba62dab68236d5aed16f13d",
+    "wof:geomhash":"52d4c90d0deda3986184ea5389298e96",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759737,
-    "wof:lastmodified":1627521987,
+    "wof:lastmodified":1695886459,
     "wof:name":"Kembe",
     "wof:parent_id":85669665,
     "wof:placetype":"county",

--- a/data/421/171/017/421171017.geojson
+++ b/data/421/171/017/421171017.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.804423,
-    "geom:area_square_m":22100292776.153397,
+    "geom:area_square_m":22100293846.82148,
     "geom:bbox":"19.045787,7.017207,20.92465,8.774918",
     "geom:latitude":7.889098,
     "geom:longitude":20.048272,
@@ -118,12 +118,13 @@
         "hasc:id":"CF.BB.BA",
         "qs_pg:id":1205647
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"CF",
     "wof:created":1459008879,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f4ecbebed2683d93cc1bfa908aee2152",
+    "wof:geomhash":"868198aa3e773865976a7bb2cb498293",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421171017,
-    "wof:lastmodified":1636501625,
+    "wof:lastmodified":1695886792,
     "wof:name":"Bamingui",
     "wof:parent_id":85669689,
     "wof:placetype":"county",

--- a/data/856/323/91/85632391.geojson
+++ b/data/856/323/91/85632391.geojson
@@ -1257,6 +1257,7 @@
         "hasc:id":"CF",
         "icao:code":"TL",
         "ioc:id":"CAF",
+        "iso:code":"CF",
         "itu:id":"CAF",
         "m49:code":"140",
         "marc:id":"cx",
@@ -1270,6 +1271,7 @@
         "wk:page":"Central African Republic",
         "wmo:id":"CE"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CF",
     "wof:country_alpha3":"CAF",
     "wof:geom_alt":[
@@ -1293,7 +1295,7 @@
         "fra",
         "sag"
     ],
-    "wof:lastmodified":1694639537,
+    "wof:lastmodified":1695881194,
     "wof:name":"Central African Republic",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/696/55/85669655.geojson
+++ b/data/856/696/55/85669655.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005709,
-    "geom:area_square_m":70388655.74943,
+    "geom:area_square_m":70388792.873705,
     "geom:bbox":"18.524309,4.322539,18.644218,4.431223",
     "geom:latitude":4.379529,
     "geom:longitude":18.565811,
@@ -578,11 +578,13 @@
         "gn:id":2596686,
         "gp:id":2345105,
         "hasc:id":"CF.BG",
+        "iso:code":"CF-BGF",
         "iso:id":"CF-BGF",
         "qs_pg:id":423673,
         "unlc:id":"CF-BGF",
         "wd:id":"Q3832"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         421181445
     ],
@@ -590,7 +592,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1dbc2a2aaad41cdee65bd1169f3ba878",
+    "wof:geomhash":"e883966dc6695019058b8aa4c00e76f3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -607,7 +609,7 @@
         "fra",
         "sag"
     ],
-    "wof:lastmodified":1690865855,
+    "wof:lastmodified":1695884364,
     "wof:name":"Bangui",
     "wof:parent_id":85632391,
     "wof:placetype":"region",

--- a/data/856/696/61/85669661.geojson
+++ b/data/856/696/61/85669661.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.595591,
-    "geom:area_square_m":31966165575.529942,
+    "geom:area_square_m":31966164727.401581,
     "geom:bbox":"16.489515,3.871299,19.141676,5.907557",
     "geom:latitude":5.118111,
     "geom:longitude":17.993562,
@@ -297,17 +297,19 @@
         "gn:id":2383765,
         "gp:id":2345104,
         "hasc:id":"CF.MP",
+        "iso:code":"CF-MP",
         "iso:id":"CF-MP",
         "qs_pg:id":988722,
         "unlc:id":"CF-MP",
         "wd:id":"Q378970",
         "wk:page":"Ombella-M'Poko"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"61f56ef524276bb1c90fd9c9812b5a07",
+    "wof:geomhash":"515eced133bc71b7303e87753622a878",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -324,7 +326,7 @@
         "fra",
         "sag"
     ],
-    "wof:lastmodified":1690865852,
+    "wof:lastmodified":1695884364,
     "wof:name":"Ombella M'Poko",
     "wof:parent_id":85632391,
     "wof:placetype":"region",

--- a/data/856/696/65/85669665.geojson
+++ b/data/856/696/65/85669665.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.364558,
-    "geom:area_square_m":16811022938.507101,
+    "geom:area_square_m":16811023018.095146,
     "geom:bbox":"20.464951,4.225172,22.150751,5.728317",
     "geom:latitude":4.898463,
     "geom:longitude":21.361829,
@@ -297,17 +297,19 @@
         "gn:id":240396,
         "gp:id":2345090,
         "hasc:id":"CF.BK",
+        "iso:code":"CF-BK",
         "iso:id":"CF-BK",
         "qs_pg:id":946778,
         "unlc:id":"CF-BK",
         "wd:id":"Q810484",
         "wk:page":"Basse-Kotto"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c9badc8b0a0047526447e2302c473686",
+    "wof:geomhash":"559876fdbf74429961b6b4cdc4eedbde",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -324,7 +326,7 @@
         "fra",
         "sag"
     ],
-    "wof:lastmodified":1690865855,
+    "wof:lastmodified":1695884898,
     "wof:name":"Basse-Kotto",
     "wof:parent_id":85632391,
     "wof:placetype":"region",

--- a/data/856/696/67/85669667.geojson
+++ b/data/856/696/67/85669667.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.506424,
-    "geom:area_square_m":18577491914.203148,
+    "geom:area_square_m":18577492057.987808,
     "geom:bbox":"16.736014,3.469993,18.626193,5.024674",
     "geom:latitude":4.173594,
     "geom:longitude":17.616005,
@@ -294,17 +294,19 @@
         "gn:id":2385105,
         "gp:id":2345095,
         "hasc:id":"CF.LB",
+        "iso:code":"CF-LB",
         "iso:id":"CF-LB",
         "qs_pg:id":984074,
         "unlc:id":"CF-LB",
         "wd:id":"Q821037",
         "wk:page":"Lobaye"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"76c591b22811582127b56934ab0ae3bc",
+    "wof:geomhash":"fa13d5c80b07102e906e22975290b687",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -321,7 +323,7 @@
         "fra",
         "sag"
     ],
-    "wof:lastmodified":1690865853,
+    "wof:lastmodified":1695884898,
     "wof:name":"Lobaye",
     "wof:parent_id":85632391,
     "wof:placetype":"region",

--- a/data/856/696/71/85669671.geojson
+++ b/data/856/696/71/85669671.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.405714,
-    "geom:area_square_m":29652000787.28775,
+    "geom:area_square_m":29651998845.979439,
     "geom:bbox":"14.673963,3.675451,17.121381,5.390393",
     "geom:latitude":4.568167,
     "geom:longitude":15.91451,
@@ -292,17 +292,19 @@
         "gn:id":2386161,
         "gp:id":2345092,
         "hasc:id":"CF.HS",
+        "iso:code":"CF-HS",
         "iso:id":"CF-HS",
         "qs_pg:id":946779,
         "unlc:id":"CF-HS",
         "wd:id":"Q848567",
         "wk:page":"Mamb\u00e9r\u00e9-Kad\u00e9\u00ef"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f6953d1da887deafd560f377cb881e90",
+    "wof:geomhash":"61932d24279d58d381bc65675e4d988a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -319,7 +321,7 @@
         "fra",
         "sag"
     ],
-    "wof:lastmodified":1690865856,
+    "wof:lastmodified":1695884364,
     "wof:name":"Mamb\u00e9r\u00e9-Kad\u00e9\u00ef",
     "wof:parent_id":85632391,
     "wof:placetype":"region",

--- a/data/856/696/75/85669675.geojson
+++ b/data/856/696/75/85669675.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.504517,
-    "geom:area_square_m":18569254431.841858,
+    "geom:area_square_m":18569252377.94976,
     "geom:bbox":"15.284032,2.223053,17.373091,4.259798",
     "geom:latitude":3.462834,
     "geom:longitude":16.294602,
@@ -289,16 +289,18 @@
         "gn:id":2383204,
         "gp:id":2345103,
         "hasc:id":"CF.SE",
+        "iso:code":"CF-SE",
         "iso:id":"CF-SE",
         "qs_pg:id":887939,
         "wd:id":"Q856237",
         "wk:page":"Sangha-Mba\u00e9r\u00e9"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b204b8749fff8e809b389aacb3c79590",
+    "wof:geomhash":"d99df21ddf890093d131473f4b0013ea",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -315,7 +317,7 @@
         "fra",
         "sag"
     ],
-    "wof:lastmodified":1690865854,
+    "wof:lastmodified":1695884364,
     "wof:name":"Sangha-Mba\u00e9r\u00e9",
     "wof:parent_id":85632391,
     "wof:placetype":"region",

--- a/data/856/696/81/85669681.geojson
+++ b/data/856/696/81/85669681.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.226172,
-    "geom:area_square_m":27390258689.258766,
+    "geom:area_square_m":27390257829.240517,
     "geom:bbox":"14.415098,4.940694,16.526286,6.756808",
     "geom:latitude":5.699523,
     "geom:longitude":15.376937,
@@ -292,17 +292,19 @@
         "gn:id":2384205,
         "gp:id":2345097,
         "hasc:id":"CF.NM",
+        "iso:code":"CF-NM",
         "iso:id":"CF-NM",
         "qs_pg:id":257794,
         "unlc:id":"CF-NM",
         "wd:id":"Q742455",
         "wk:page":"Nana-Mamb\u00e9r\u00e9"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"02e0be7a489c687a4fb72b70c6a20b0c",
+    "wof:geomhash":"7b606e3328c3782c54a923d9daca852d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -319,7 +321,7 @@
         "fra",
         "sag"
     ],
-    "wof:lastmodified":1690865854,
+    "wof:lastmodified":1695884364,
     "wof:name":"Nana-Mamb\u00e9r\u00e9",
     "wof:parent_id":85632391,
     "wof:placetype":"region",

--- a/data/856/696/85/85669685.geojson
+++ b/data/856/696/85/85669685.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.602699,
-    "geom:area_square_m":31959882662.043625,
+    "geom:area_square_m":31959882918.423103,
     "geom:bbox":"14.94182,5.55595,17.131125,7.885918",
     "geom:latitude":6.729395,
     "geom:longitude":16.13815,
@@ -292,17 +292,19 @@
         "gn:id":2383650,
         "gp:id":2345100,
         "hasc:id":"CF.OP",
+        "iso:code":"CF-OP",
         "iso:id":"CF-OP",
         "qs_pg:id":59601,
         "unlc:id":"CF-OP",
         "wd:id":"Q848591",
         "wk:page":"Ouham-Pend\u00e9"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b92f88baa267b9a81c526a332f0407e5",
+    "wof:geomhash":"da0fbb6ca9b8f3c2ed91b9c55266fed7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -319,7 +321,7 @@
         "fra",
         "sag"
     ],
-    "wof:lastmodified":1690865856,
+    "wof:lastmodified":1695884365,
     "wof:name":"Ouham-Pend\u00e9",
     "wof:parent_id":85632391,
     "wof:placetype":"region",

--- a/data/856/696/89/85669689.geojson
+++ b/data/856/696/89/85669689.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.800272,
-    "geom:area_square_m":58713150805.015472,
+    "geom:area_square_m":58713153084.996872,
     "geom:bbox":"18.860711,7.017207,22.393709,9.773887",
     "geom:latitude":8.421658,
     "geom:longitude":20.573219,
@@ -300,17 +300,19 @@
         "gn:id":240591,
         "gp:id":2345089,
         "hasc:id":"CF.BB",
+        "iso:code":"CF-BB",
         "iso:id":"CF-BB",
         "qs_pg:id":946777,
         "unlc:id":"CF-BB",
         "wd:id":"Q741025",
         "wk:page":"Bamingui-Bangoran"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b0e3fbcd3c131658945129aff07df0cd",
+    "wof:geomhash":"dbdefdee9707ccf9e9aa5fcb7f3ff565",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -327,7 +329,7 @@
         "fra",
         "sag"
     ],
-    "wof:lastmodified":1690865853,
+    "wof:lastmodified":1695884898,
     "wof:name":"Bamingui-Bangoran",
     "wof:parent_id":85632391,
     "wof:placetype":"region",

--- a/data/856/696/93/85669693.geojson
+++ b/data/856/696/93/85669693.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.610049,
-    "geom:area_square_m":19751388176.429012,
+    "geom:area_square_m":19751387563.930347,
     "geom:bbox":"18.64847,6.433298,20.159784,8.567002",
     "geom:latitude":7.190624,
     "geom:longitude":19.331092,
@@ -293,16 +293,18 @@
         "gn:id":2386243,
         "gp:id":2345102,
         "hasc:id":"CF.KB",
+        "iso:code":"CF-KB",
         "iso:id":"CF-KB",
         "qs_pg:id":946784,
         "wd:id":"Q856227",
         "wk:page":"Nana-Gr\u00e9bizi"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bdea3cf0f182da9a590ff0c9fec97ac2",
+    "wof:geomhash":"4b25808aa96a24ffee52dfcecfa2c08f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -319,7 +321,7 @@
         "fra",
         "sag"
     ],
-    "wof:lastmodified":1690865853,
+    "wof:lastmodified":1695884364,
     "wof:name":"Nana-Gribizi",
     "wof:parent_id":85632391,
     "wof:placetype":"region",

--- a/data/856/696/97/85669697.geojson
+++ b/data/856/696/97/85669697.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.345339,
-    "geom:area_square_m":16549777638.426111,
+    "geom:area_square_m":16549778648.576616,
     "geom:bbox":"18.609339,4.938316,20.017423,6.5538",
     "geom:latitude":5.800323,
     "geom:longitude":19.297212,
@@ -292,17 +292,19 @@
         "gn:id":2385836,
         "gp:id":2345094,
         "hasc:id":"CF.KG",
+        "iso:code":"CF-KG",
         "iso:id":"CF-KG",
         "qs_pg:id":946780,
         "unlc:id":"CF-KG",
         "wd:id":"Q848572",
         "wk:page":"K\u00e9mo"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"845633c1048248a515a6e26a426801c3",
+    "wof:geomhash":"59aba536f8f74495bbff4d3b70a6d1fd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -319,7 +321,7 @@
         "fra",
         "sag"
     ],
-    "wof:lastmodified":1690865856,
+    "wof:lastmodified":1695884364,
     "wof:name":"K\u00e9mo",
     "wof:parent_id":85632391,
     "wof:placetype":"region",

--- a/data/856/696/99/85669699.geojson
+++ b/data/856/696/99/85669699.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.007786,
-    "geom:area_square_m":49270429542.893944,
+    "geom:area_square_m":49270428141.559128,
     "geom:bbox":"19.464499,4.530387,21.944464,7.705298",
     "geom:latitude":6.129043,
     "geom:longitude":20.750041,
@@ -297,17 +297,19 @@
         "gn:id":236887,
         "gp:id":2345098,
         "hasc:id":"CF.UK",
+        "iso:code":"CF-UK",
         "iso:id":"CF-UK",
         "qs_pg:id":257795,
         "unlc:id":"CF-UK",
         "wd:id":"Q848560",
         "wk:page":"Ouaka"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d8d8649ca16ff626a408eb8569ec9a11",
+    "wof:geomhash":"a2880317a0f02ae3c67fa75d87ca0f53",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -324,7 +326,7 @@
         "fra",
         "sag"
     ],
-    "wof:lastmodified":1690865855,
+    "wof:lastmodified":1695884898,
     "wof:name":"Ouaka",
     "wof:parent_id":85632391,
     "wof:placetype":"region",

--- a/data/856/697/01/85669701.geojson
+++ b/data/856/697/01/85669701.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.328144,
-    "geom:area_square_m":53125328425.60479,
+    "geom:area_square_m":53125329122.661026,
     "geom:bbox":"16.676987,5.560376,19.075819,8.57393",
     "geom:latitude":6.916371,
     "geom:longitude":17.890476,
@@ -296,16 +296,18 @@
         "gn:id":2383653,
         "gp:id":2345099,
         "hasc:id":"CF.AC",
+        "iso:code":"CF-AC",
         "iso:id":"CF-AC",
         "qs_pg:id":887938,
         "wd:id":"Q726620",
         "wk:page":"Ouham"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6ad5962213f1d2f2eee09811d00befc7",
+    "wof:geomhash":"bb00306af9db77268dae67f0a4909c4e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -322,7 +324,7 @@
         "fra",
         "sag"
     ],
-    "wof:lastmodified":1690865852,
+    "wof:lastmodified":1695884898,
     "wof:name":"Ouham",
     "wof:parent_id":85632391,
     "wof:placetype":"region",

--- a/data/856/697/03/85669703.geojson
+++ b/data/856/697/03/85669703.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.863557,
-    "geom:area_square_m":47070005435.121658,
+    "geom:area_square_m":47070004872.820221,
     "geom:bbox":"20.817173,8.579844,23.696254,11.017957",
     "geom:latitude":9.827026,
     "geom:longitude":22.51152,
@@ -303,17 +303,19 @@
         "gn:id":236178,
         "gp:id":2345101,
         "hasc:id":"CF.VK",
+        "iso:code":"CF-VK",
         "iso:id":"CF-VK",
         "qs_pg:id":211639,
         "unlc:id":"CF-VK",
         "wd:id":"Q848585",
         "wk:page":"Vakaga"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"618369d3c3ef28be6f2bda251602d3bc",
+    "wof:geomhash":"994a0cbe2369c1d71060c1cc4e388c5a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -330,7 +332,7 @@
         "fra",
         "sag"
     ],
-    "wof:lastmodified":1690865850,
+    "wof:lastmodified":1695884897,
     "wof:name":"Vakaga",
     "wof:parent_id":85632391,
     "wof:placetype":"region",

--- a/data/856/697/05/85669705.geojson
+++ b/data/856/697/05/85669705.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":7.045908,
-    "geom:area_square_m":86377851649.12738,
+    "geom:area_square_m":86377850685.428711,
     "geom:bbox":"21.101907,5.479312,24.58896,9.241508",
     "geom:latitude":7.468826,
     "geom:longitude":22.922329,
@@ -296,17 +296,19 @@
         "gn:id":238640,
         "gp:id":2345091,
         "hasc:id":"CF.HK",
+        "iso:code":"CF-HK",
         "iso:id":"CF-HK",
         "qs_pg:id":74752,
         "unlc:id":"CF-HK",
         "wd:id":"Q848596",
         "wk:page":"Haute-Kotto"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7ef1dc2f80216c6e7581835639c7400c",
+    "wof:geomhash":"ffb6d0e4f2e8aed96a4e137a2e7bf57b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -323,7 +325,7 @@
         "fra",
         "sag"
     ],
-    "wof:lastmodified":1690865851,
+    "wof:lastmodified":1695884897,
     "wof:name":"Haute-Kotto",
     "wof:parent_id":85632391,
     "wof:placetype":"region",

--- a/data/856/697/07/85669707.geojson
+++ b/data/856/697/07/85669707.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.614299,
-    "geom:area_square_m":56705411553.30806,
+    "geom:area_square_m":56705411139.452606,
     "geom:bbox":"24.261284,4.893125,27.458305,8.286028",
     "geom:latitude":6.308472,
     "geom:longitude":25.587993,
@@ -299,17 +299,19 @@
         "gn:id":238639,
         "gp:id":2345093,
         "hasc:id":"CF.HM",
+        "iso:code":"CF-HM",
         "iso:id":"CF-HM",
         "qs_pg:id":190323,
         "unlc:id":"CF-HM",
         "wd:id":"Q848578",
         "wk:page":"Haut-Mbomou"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"eec4a0b1ba7e688969ec228862aaf606",
+    "wof:geomhash":"a7d0d00fbdeb66cab017818d91c25c43",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -326,7 +328,7 @@
         "fra",
         "sag"
     ],
-    "wof:lastmodified":1690865851,
+    "wof:lastmodified":1695884897,
     "wof:name":"Haut-Mbomou",
     "wof:parent_id":85632391,
     "wof:placetype":"region",

--- a/data/856/697/09/85669709.geojson
+++ b/data/856/697/09/85669709.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.894755,
-    "geom:area_square_m":60242750861.710091,
+    "geom:area_square_m":60242751079.323235,
     "geom:bbox":"21.737712,4.115013,25.189555,6.752035",
     "geom:latitude":5.504824,
     "geom:longitude":23.391517,
@@ -296,16 +296,18 @@
         "gn:id":237556,
         "gp:id":2345096,
         "hasc:id":"CF.MB",
+        "iso:code":"CF-MB",
         "iso:id":"CF-MB",
         "qs_pg:id":946781,
         "wd:id":"Q848582",
         "wk:page":"Mbomou"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CF",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e60757e0230779907a5af9910a28b727",
+    "wof:geomhash":"22c80c0b5961847bfefb478155f9934c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -322,7 +324,7 @@
         "fra",
         "sag"
     ],
-    "wof:lastmodified":1690865852,
+    "wof:lastmodified":1695884898,
     "wof:name":"Mbomou",
     "wof:parent_id":85632391,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.